### PR TITLE
feat(repo): update codeowners and gitignore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @neonbit101 @AnarAskar @avanishchandra @JoaquinVeraOrtega @AksharGoyal @anthonbrooks @akaneme @Bilalnasir057558 @Lorevdh @mihaimiron1 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ venv/
 __pycache__/
 *.pyc
 .env
+.cache/
+*.swp
+**.egg-info*
+.mypy_cache/
+.coverage
+.pytest_cache/
+.DS_STORE
+node_modules/


### PR DESCRIPTION
Adding codeowners
- to get notifications when a PR is ready to review
- to do: update hierarchy for directories in future where few members will be responsible for reviewing frontend and backend changes