### PR TITLE
Add DB healthcheck on server startup and small change in backend readme

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -39,7 +39,7 @@ Edit the .env file:
 ### 3. Start the Application
 
     cd backend
-    docker-compose up --build
+    docker compose up --build
 
 ---
 
@@ -54,37 +54,37 @@ Edit the .env file:
 ## Docker Commands
 
     # Start services
-    docker-compose up
+    docker compose up
 
     # Start in background
-    docker-compose up -d
+    docker compose up -d
 
     # Stop services
-    docker-compose down
+    docker compose down
 
     # View logs
-    docker-compose logs -f
+    docker compose logs -f
 
     # Rebuild
-    docker-compose build --no-cache
+    docker compose build --no-cache
 
 ---
 
 ## Django Commands
 
     # Run inside container
-    docker-compose exec django-web python manage.py <command>
+    docker compose exec django-web python manage.py <command>
 
     # Examples:
-    docker-compose exec django-web python manage.py migrate
-    docker-compose exec django-web python manage.py createsuperuser
+    docker compose exec django-web python manage.py migrate
+    docker compose exec django-web python manage.py createsuperuser
 
 ---
 
 ### To Reset Database
 
-    docker-compose down -v
-    docker-compose up -d
-    docker-compose exec django-web python manage.py migrate
+    docker compose down -v
+    docker compose up -d
+    docker compose exec django-web python manage.py migrate
 
 ---

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -11,7 +11,13 @@ services:
      - postgres_data:/var/lib/postgresql/data
    env_file:
      - .env
- 
+   healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USERNAME} -d ${DATABASE_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
  django-web:
    build: .
    volumes:
@@ -20,7 +26,8 @@ services:
    ports:
      - "8000:8000"
    depends_on:
-     - db
+     db:
+      condition: service_healthy
    environment:
      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
      DEBUG: ${DEBUG}


### PR DESCRIPTION
- Summary
Add healthcheck in docker compose to ensure server is only trying to connect to the database after postgres is ready to accept connections.

- Linked issue
Closes #46 

- Notes
Also made some changes in the readme to stop using the deprecated 'docker-compose' command, we should use 'docker compose' instead