### PR TITLE
Add refresh token handler

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -1,3 +1,4 @@
+
 """
 Django settings for backend project.
 
@@ -38,10 +39,11 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    "rest_framework",
-    "user.apps.UserConfig",
-   'drf_yasg',
-    "mealTrain",
+    'rest_framework',
+    'user.apps.UserConfig',
+    'drf_yasg',
+    'mealTrain',
+    'rest_framework_simplejwt.token_blacklist',
 ]
 
 MIDDLEWARE = [
@@ -153,4 +155,7 @@ SWAGGER_SETTINGS = {
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+    'ROTATE_REFRESH_TOKENS': True,
+    'BLACKLIST_AFTER_ROTATION': True,
+    'UPDATE_LAST_LOGIN': True,  # Updates user's last_login on token refresh
 }

--- a/backend/user/urls.py
+++ b/backend/user/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
 
 from .views import RegisterView, LoginView, LogoutView, MeView
+from rest_framework_simplejwt.views import TokenRefreshView
 
 urlpatterns = [
     path("auth/register", RegisterView.as_view()),
     path("auth/login", LoginView.as_view()),
     path("auth/logout", LogoutView.as_view()),
+    path('auth/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path("me", MeView.as_view()),
 ]


### PR DESCRIPTION
- Summary
Added refresh token handler endpoint to let the client obtain a new access/refresh token pair.

- Linked issue
Closes #74

- Notes
This endpoint is needed because the frontend needs to refresh the access token when it expires in order to keep the user loged in.
Also changed JWT settings to blacklist the refresh token once is used, generating a new one.