### PR TITLE
Add CORS_ALLOW_CREDENTIALS setting to enable credentials in CORS requests

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -62,6 +62,8 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
 ]
 
+CORS_ALLOW_CREDENTIALS = True
+
 ROOT_URLCONF = 'backend.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
- Summary
Added CORS_ALLOW_CREDENTIALS in settings.py

- Notes
Without this config, the requests from the frontend client wont be allowed