### PR TITLE
Link meal train cards to their respective detail views

### DIFF
--- a/frontend/src/components/dashboard/MealTrainSection.jsx
+++ b/frontend/src/components/dashboard/MealTrainSection.jsx
@@ -30,11 +30,7 @@ export default function MealTrainSection({
       </div>
 
       {items.map((item, i) => (
-        <Link
-          key={item.id}
-          to={`/view-meal-train/${item.id}`}
-          className="cursor-pointer"
-        >
+        <Link key={item.id} to={`/view-meal-train/${item.id}`} className="cursor-pointer">
           <MealTrainCard {...item} showTopBorder={i !== 0} />
         </Link>
       ))}
@@ -49,7 +45,6 @@ export default function MealTrainSection({
             <MealTrainCard {...item} />
           </Link>
         ))}
-
 
       <button
         className="mx-auto text-[#f68300] font-semibold flex items-center gap-1"


### PR DESCRIPTION
This PR makes all meal trains in the user dashboard clickable. Each meal train card is now wrapped in a Link that navigates to /view-meal-train/:id, allowing users to open the corresponding meal train page directly.

Closes #153 and closes #154 