### PR TITLE
Bugfix/handle membership correctly get single train endpoint

### DIFF
--- a/backend/mealTrain/views.py
+++ b/backend/mealTrain/views.py
@@ -55,6 +55,7 @@ class MealTrainListCreateView(APIView):
         )
         if serializer.is_valid():
             serializer.save(organizer=request.user)
+            serializer = MealTrainMembershipSerializer()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -83,12 +84,13 @@ class MealTrainDetailView(APIView):
     )
     def get(self, request, pk):
         train = self.get_meal_train(pk)
+        memberships = MealTrainMembership.objects.filter(user=request.user, meal_train=train)
         if not is_allowed_participant(request.user, train):
             self.permission_denied(
                 self.request,
                 "Only approved members can retrieve the meal train details.",
             )        
-        serializer = MealTrainSerializer(train, context={"request": request})
+        serializer = MealTrainSerializer(train, context={"request": request, "memberships": memberships})
         return Response(serializer.data)
 
     @swagger_auto_schema(
@@ -312,8 +314,11 @@ class MealTrainMembershipListCreateView(APIView):
     )
     def get(self, request, meal_train_id):
         train = get_object_or_404(MealTrain, pk=meal_train_id)
+        memberships = []
         if train.organizer == request.user:
-            memberships = MealTrainMembership.objects.filter(meal_train=train)
+            memberships.append({'meal_train': train, 'user': request.user, 'status': 'owner'})
+            guests_memberships = MealTrainMembership.objects.filter(meal_train=train)
+            memberships.extend(guests_memberships)
         else:
             memberships = MealTrainMembership.objects.filter(
                 meal_train=train, user=request.user

--- a/frontend/src/pages/ViewMealTrain.jsx
+++ b/frontend/src/pages/ViewMealTrain.jsx
@@ -18,11 +18,10 @@ export default function ViewMealTrain() {
     async function run() {
       try {
         const res = await axiosClient.get(`/api/mealtrains/${id}/memberships/`);
-
         if (res.data.length === 0) {
           setMembershipStatus('none');
         } else {
-          setMembershipStatus(res.data[0].status); // "pending", "approved", "rejected"
+          setMembershipStatus(res.data[0].status); // "pending", "approved", "rejected", "owner"
         }
       } catch (err) {
         console.error(err);
@@ -70,7 +69,7 @@ export default function ViewMealTrain() {
           />
         )}
 
-        {membershipStatus === 'approved' && <ViewMealCard />}
+        {(membershipStatus === 'approved' || membershipStatus === 'owner') && <ViewMealCard />}
 
         {membershipStatus === 'rejected' && (
           <p className="text-center text-red-600 mt-10">Your request was rejected.</p>


### PR DESCRIPTION
- Summary
Add 'owner'  type membership in the GET /api/mealtrains/{meal_train_id}/memberships/ response.
Change the View Meal Page to handle the 'owner' status.

- Linked issue
Closes #190 

- Notes
Added back the permission checks in the GET /api/mealtrains/{id}/, this check was removed as a hotfix to bypass an issue that is already resolved, so I'm restoring it to enhance data privacy.