### PR TITLE
Update CustomCalendar styles for responsive design: set height to aut…

### DIFF
--- a/frontend/src/components/meal-train/CustomCalendar.css
+++ b/frontend/src/components/meal-train/CustomCalendar.css
@@ -4,7 +4,8 @@
   outline: none;
   margin: 0 auto;
   width: 400px;
-  height: 390px;
+  height: auto;
+  max-width: 100%;
 }
 
 .react-calendar__tile {


### PR DESCRIPTION
Fixes #193 by correcting the calendar overflow issue in months that span 6 weeks.
The problem was caused by a fixed height (height: 390px) in CustomCalendar.css, which prevented the calendar from expanding when an extra week was present. Removed the fixed height from .react-calendar and replaced it with height: auto
