### PR TITLE
Remove unused error message in CreateMeal component

### DIFF
--- a/frontend/src/pages/CreateMeal.jsx
+++ b/frontend/src/pages/CreateMeal.jsx
@@ -226,12 +226,6 @@ export default function CreateMeal() {
                 Selected date: {formatDate(mealDate)}
               </p>
             )}
-
-            {error && (
-              <p className="font-semibold flex items-center justify-center mt-4  bg-red-500 p-3 text-white w-full">
-                Please select a meal date and type that is not already chosen
-              </p>
-            )}
           </div>
 
           <div className="w-full flex flex-col mb-6">


### PR DESCRIPTION
- Summary
Removed the unused error message in create a meal form

- Notes
We already block the user from selecting a date that is not valid or a meal type not valid within a valid date, so the error message about selecting a valid date and meal type will never be displayed, I think we should remove it