### PR TITLE
Remove Avanish from the team list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Leadership
 Participants
 
 <ul>
-  <li><a href="https://github.com/avanishchandra">Avanish</a></li>
   <li><a href="https://github.com/JoaquinVeraOrtega">Joaquin</a></li>
   <li><a href="https://github.com/AksharGoyal">Akshar</a></li>
   <li><a href="https://github.com/anthonbrooks">Anthony</a></li>


### PR DESCRIPTION
Updates the README to accurately reflect the list of participants.
Removed contributors who did not actively participate in the project
